### PR TITLE
Fix Swift.Dictionary to NSMutableDictionary cast issue.

### DIFF
--- a/Sources/SpatialMediaKit/SpatialVideoMerger.swift
+++ b/Sources/SpatialMediaKit/SpatialVideoMerger.swift
@@ -66,7 +66,7 @@ public class SpatialVideoMerger {
     let heroEye =
       leftIsPrimary ? kCMFormatDescriptionHeroEye_Left : kCMFormatDescriptionHeroEye_Right
 
-    let outputSettingsDict: [String: Any] = [
+    var outputSettingsDict: [String: Any] = [
       AVVideoWidthKey: outputWidth,
       AVVideoHeightKey: outputHeight,
       AVVideoColorPropertiesKey: [
@@ -88,9 +88,11 @@ public class SpatialVideoMerger {
     ]
 
     if let hDisparityAdj = hDisparityAdj {
-      let compressionProps =
-        outputSettingsDict[AVVideoCompressionPropertiesKey] as! NSMutableDictionary
-      compressionProps[kVTCompressionPropertyKey_HorizontalDisparityAdjustment] = hDisparityAdj
+      if let compressionPropsDict = outputSettingsDict[AVVideoCompressionPropertiesKey] as? [String: Any] {
+        let compressionProps = NSMutableDictionary(dictionary: compressionPropsDict)
+        compressionProps[kVTCompressionPropertyKey_HorizontalDisparityAdjustment] = hDisparityAdj
+        outputSettingsDict[AVVideoCompressionPropertiesKey] = compressionProps
+      }
     }
 
     let assetWriterInput = AVAssetWriterInput(


### PR DESCRIPTION
Fixed an issue where specifying the `--horizontal-disparity-adjustment` option to merge command caused the following cast error:
`Could not cast value of type 'Swift.Dictionary<__C.CFStringRef, Any>' (0x127835f10) to 'NSMutableDictionary' (0x127835f68).`
This error has also been reported in #2.