### PR TITLE
Add color depth parameter to SpatialVideoMerger

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ OPTIONS:
   -r, --right-file <right-file>
                           The right eye media file to merge.
   -q, --quality <quality> Output video quality [0-100]. 50 is a good default value.
+  -c, --color-depth <color-depth>
+                          Set the color depth of the output file. (default: 8)
   --left-is-primary       Set the left file as the "hero" stream that is displayed when viewing in 2D.
   --right-is-primary      Set the right file as the "hero" stream that is displayed when viewing in 2D.
   --horizontal-field-of-view <horizontal-field-of-view>

--- a/Sources/SpatialMediaKit/SpatialVideoMerger.swift
+++ b/Sources/SpatialMediaKit/SpatialVideoMerger.swift
@@ -51,12 +51,14 @@ public class SpatialVideoMerger {
     colorMatrix: String,
     hFov: Int,
     hDisparityAdj: Int?,
-    leftIsPrimary: Bool
+    leftIsPrimary: Bool,
+    colorDepth: Int
   )
     -> (
       AVAssetWriter, AVAssetWriterInputTaggedPixelBufferGroupAdaptor
     )
   {
+      let profileLevel = colorDepth == 10 ? "HEVCMain10" : "HEVCMain"
 
     let assetWriter = try! AVAssetWriter(
       outputURL: outputUrl,
@@ -242,7 +244,8 @@ public class SpatialVideoMerger {
     quality: Float,
     horizontalFieldOfView: Int,
     horizontalDisparityAdjustment: Int?,
-    leftIsPrimary: Bool
+    leftIsPrimary: Bool,
+    colorDepth: Int
   ) {
     do {
       let leftSourceMovieUrl = URL(fileURLWithPath: leftFilePath)
@@ -317,7 +320,9 @@ public class SpatialVideoMerger {
         outputFrameRate: leftFrameRate, videoQuality: quality,
         colorPrimaries: colorPrimaries, transferFunction: transferFunction,
         colorMatrix: colorMatrix, hFov: horizontalFieldOfView,
-        hDisparityAdj: horizontalDisparityAdjustment, leftIsPrimary: leftIsPrimary)
+        hDisparityAdj: horizontalDisparityAdjustment, leftIsPrimary: leftIsPrimary,
+        colorDepth: colorDepth
+      )
 
       let semaphore = DispatchSemaphore(value: 0)
 

--- a/Sources/SpatialMediaKit/SpatialVideoMerger.swift
+++ b/Sources/SpatialMediaKit/SpatialVideoMerger.swift
@@ -58,7 +58,7 @@ public class SpatialVideoMerger {
       AVAssetWriter, AVAssetWriterInputTaggedPixelBufferGroupAdaptor
     )
   {
-      let profileLevel = colorDepth == 10 ? kVTProfileLevel_HEVC_Main_AutoLevel : kVTProfileLevel_HEVC_Main10_AutoLevel
+      let profileLevel = colorDepth == 10 ? kVTProfileLevel_HEVC_Main10_AutoLevel : kVTProfileLevel_HEVC_Main_AutoLevel
 
     let assetWriter = try! AVAssetWriter(
       outputURL: outputUrl,

--- a/Sources/SpatialMediaKit/SpatialVideoMerger.swift
+++ b/Sources/SpatialMediaKit/SpatialVideoMerger.swift
@@ -58,7 +58,7 @@ public class SpatialVideoMerger {
       AVAssetWriter, AVAssetWriterInputTaggedPixelBufferGroupAdaptor
     )
   {
-      let profileLevel = colorDepth == 10 ? "HEVCMain10" : "HEVCMain"
+      let profileLevel = colorDepth == 10 ? kVTProfileLevel_HEVC_Main_AutoLevel : kVTProfileLevel_HEVC_Main10_AutoLevel
 
     let assetWriter = try! AVAssetWriter(
       outputURL: outputUrl,
@@ -79,7 +79,7 @@ public class SpatialVideoMerger {
       ],
       AVVideoCompressionPropertiesKey: [
         kVTCompressionPropertyKey_HDRMetadataInsertionMode: kVTHDRMetadataInsertionMode_Auto,
-        kVTCompressionPropertyKey_ProfileLevel: kVTProfileLevel_HEVC_Main10_AutoLevel,
+        kVTCompressionPropertyKey_ProfileLevel: profileLevel,
         kVTCompressionPropertyKey_Quality: videoQuality,
         kVTCompressionPropertyKey_PreserveDynamicHDRMetadata: true,
         kVTCompressionPropertyKey_MVHEVCVideoLayerIDs: [0, 1] as CFArray,

--- a/Sources/SpatialMediaKitTool/SpatialMediaKitTool.swift
+++ b/Sources/SpatialMediaKitTool/SpatialMediaKitTool.swift
@@ -80,6 +80,9 @@ extension SpatialMediaKitTool {
     @Flag(help: "Set the right file as the \"hero\" stream that is displayed when viewing in 2D.")
     var rightIsPrimary: Bool = false
 
+    @Option(name: .shortAndLong, help: "Set the color depth of the output file.")
+    var colorDepth: Int = 8
+
     @Option(
       name: .long,
       help:
@@ -133,7 +136,9 @@ extension SpatialMediaKitTool {
         quality: qualityFloat,
         horizontalFieldOfView: Int(horizontalFieldOfView * 1000),
         horizontalDisparityAdjustment: horizontalDisparityAdjustment,
-        leftIsPrimary: leftIsPrimary)
+        leftIsPrimary: leftIsPrimary,
+        colorDepth: colorDepth
+      )
     }
   }
 }


### PR DESCRIPTION
The color depth parameter has been added to the SpatialVideoMerger constructors and used to determine the profile level in SpatialVideoMerger. This option is also added to the SpatialMediaKitTool for user input. The default value for color depth has been set as 8.